### PR TITLE
大佬，发现您的项目引入了org.apache.logging.log4j:log4j-core@2.16.0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
         <modelVersion>4.0.0</modelVersion>
     <groupId>org.example</groupId>
     <artifactId>suanfa</artifactId>
@@ -10,7 +10,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <tapestry-version>5.8.0</tapestry-version>
         <jackson-version>2.12.5</jackson-version>
-        <log4j-version>2.16.0</log4j-version>
+        <log4j-version>2.17.1</log4j-version>
         <json-version>1.1.4</json-version>
         <junit-version>5.7.2</junit-version>
         <yasson-version>2.0.2</yasson-version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Log4j 安全漏洞
缺陷组件：org.apache.logging.log4j:log4j-core@2.16.0
漏洞编号：CVE-2021-45105
漏洞描述：Apache Log4j是美国阿帕奇（Apache）基金会的一款基于Java的开源日志记录工具。
Apache Log4j2 2.0-alpha1到2.16.0版本（不包括2.12.3）存在安全漏洞，该漏洞源于自引用查找的不受控递归。攻击者可利用该漏洞在解释精心编制的字符串时导致拒绝服务。此问题已在2.17.0 和 2.12.3中修复。
影响范围：[2.13.0, 2.17.0)
最小修复版本：2.17.1
缺陷组件引入路径：org.example:suanfa@1.0-SNAPSHOT->org.apache.logging.log4j:log4j-core@2.16.0
```
另外我运行这个项目时，IDE的安全插件提示还有3个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p1c906